### PR TITLE
add location fitting for plants

### DIFF
--- a/src/Controller/API/FitnessController.php
+++ b/src/Controller/API/FitnessController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Controller\API;
+
+use App\Entity\Locations;
+use App\Entity\Plants;
+use App\Enum\FitnessStatus;
+use App\Enum\HumidityRequirement;
+use App\Enum\LightRequirement;
+use App\Enum\TemperatureRequirement;
+use App\Repository\LocationsRepository;
+use App\Repository\PlantsRepository;
+use App\Service\Fitness\FitnessService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/api/fitness')]
+#[IsGranted("IS_AUTHENTICATED")]
+class FitnessController extends AbstractController
+{
+    public function __construct(
+        private FitnessService      $fitnessService,
+        private LocationsRepository $locationsRepository
+    )
+    {
+    }
+
+    #[Route('/location', name: 'fitness')]
+    public function getLocation(Request $request): JsonResponse
+    {
+        $light = LightRequirement::tryFrom($request->query->get('light_requirement'));
+        $temperature = TemperatureRequirement::tryFrom($request->query->get('temperature_requirement'));
+        $humidity = HumidityRequirement::tryFrom($request->query->get('humidity_requirement'));
+
+        if ($light == null || $temperature == null || $humidity == null) {
+            return $this->json([], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        $fitness = [];
+        $locations = $this->locationsRepository->findAllByUser($this->getUser());
+        /** @var Locations $location */
+        foreach ($locations as $location) {
+            $fitness[$this->fitnessService->checkFitForPlantInLocation(
+                $light,
+                $temperature,
+                $humidity,
+                $location
+            )->getStatus()->value][$location->getId()] = $location;
+        }
+
+        return $this->json($fitness, Response::HTTP_OK, context: ['groups' => [
+            'plant:ref', 'location:ref'
+        ]]);
+    }
+}

--- a/src/Controller/PlantsController.php
+++ b/src/Controller/PlantsController.php
@@ -2,14 +2,13 @@
 
 namespace App\Controller;
 
-use App\DataFixtures\WishlistPlantFixture;
 use App\Entity\Plants;
 use App\Entity\WishlistPlants;
 use App\Form\PlantsType;
 use App\Repository\PlantsRepository;
+use App\Service\Fitness\FitnessService;
 use App\Service\Pagination\PaginationService;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\EntityRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,7 +20,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted("IS_AUTHENTICATED")]
 final class PlantsController extends AbstractController
 {
-    public function __construct()
+    public function __construct(private FitnessService $fitnessService)
     {
     }
 
@@ -80,14 +79,24 @@ final class PlantsController extends AbstractController
             return $this->redirectToRoute('app_plants_index', [], Response::HTTP_SEE_OTHER);
         }
 
+        if ($plant->getLocation()) {
+            $fitnessStatus = $this->fitnessService->checkFitForPlantInLocation(
+                $plant->getLightRequirement(),
+                $plant->getTemperatureRequirement(),
+                $plant->getHumidityRequirement(),
+                $plant->getLocation());
+        }
+
         return $this->render('plants/show.html.twig', [
             'plant' => $plant,
+            'fitnessStatus' => $fitnessStatus ?? null,
         ]);
     }
 
     #[Route('/{id}/edit', name: 'app_plants_edit', methods: ['GET', 'POST'])]
     public function edit(Request $request, Plants $plant, EntityManagerInterface $entityManager, string $uploadsPath): Response
     {
+
         //make sure that we only show plants to the owner of the plant
         if ($this->getUser() !== $plant->getUser()) {
             return $this->redirectToRoute('app_plants_index', [], Response::HTTP_SEE_OTHER);
@@ -156,7 +165,7 @@ final class PlantsController extends AbstractController
             ->setBotanicalName($plant->getBotanicalName() ?? '')
             ->setUser($plant->getUser());
 
-        if($plant->getLocation()){
+        if ($plant->getLocation()) {
             $wishlistPlant->setLocation($plant->getLocation());
         }
 

--- a/src/Entity/Locations.php
+++ b/src/Entity/Locations.php
@@ -9,6 +9,7 @@ use App\Repository\LocationsRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ORM\Entity(repositoryClass: LocationsRepository::class)]
 #[ORM\UniqueConstraint(name: 'user_location_name', columns: ['user_id', 'name'])]
@@ -17,21 +18,27 @@ class Locations
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
+    #[Groups('location:ref')]
     private ?int $id = null;
 
     #[ORM\Column(length: 50)]
+    #[Groups('location:ref')]
     private ?string $name = null;
 
     #[ORM\Column(length: 255, nullable: true)]
+    #[Groups('location:ref')]
     private ?string $description = null;
 
     #[ORM\Column(enumType: LightRequirement::class)]
+    #[Groups('location:ref')]
     private ?LightRequirement $light_condition = null;
 
     #[ORM\Column(enumType: TemperatureRequirement::class)]
+    #[Groups('location:ref')]
     private ?TemperatureRequirement $temperature_level = null;
 
     #[ORM\Column(enumType: HumidityRequirement::class)]
+    #[Groups('location:ref')]
     private ?HumidityRequirement $humidity_level = null;
 
     #[ORM\Column]

--- a/src/Enum/FitnessStatus.php
+++ b/src/Enum/FitnessStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enum;
+
+enum FitnessStatus: string
+{
+    case perfect = "geeignet";
+    case partly = "teilweise geeignet";
+    case none = "nicht geeignet";
+}

--- a/src/Enum/HumidityRequirement.php
+++ b/src/Enum/HumidityRequirement.php
@@ -2,9 +2,13 @@
 
 namespace App\Enum;
 
-enum HumidityRequirement: string
+enum HumidityRequirement: string implements RequirementInterface
 {
     case low = 'niedrig';
     case medium = 'mittel';
     case hight = 'hoch';
+    public function matches(RequirementInterface $other): bool
+    {
+        return $this === $other;
+    }
 }

--- a/src/Enum/LightRequirement.php
+++ b/src/Enum/LightRequirement.php
@@ -2,10 +2,15 @@
 
 namespace App\Enum;
 
-enum LightRequirement: string
+enum LightRequirement: string implements RequirementInterface
 {
     case shady = 'schattig';
     case halfshady = 'halbschattig';
     case bright = 'hell';
     case sunny = 'sonnig';
+
+    public function matches(RequirementInterface $other): bool
+    {
+        return $this === $other;
+    }
 }

--- a/src/Enum/RequirementInterface.php
+++ b/src/Enum/RequirementInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Enum;
+
+interface RequirementInterface
+{
+    public function matches(self $other): bool;
+}

--- a/src/Enum/TemperatureRequirement.php
+++ b/src/Enum/TemperatureRequirement.php
@@ -2,9 +2,14 @@
 
 namespace App\Enum;
 
-enum TemperatureRequirement: string
+enum TemperatureRequirement: string implements RequirementInterface
 {
     case cool = 'kühl (< 18° C)';
     case normal = 'normal (18–24°C)';
     case warm = 'warm (> 24°C)';
+
+    public function matches(RequirementInterface $other): bool
+    {
+        return $this === $other;
+    }
 }

--- a/src/Repository/LocationsRepository.php
+++ b/src/Repository/LocationsRepository.php
@@ -25,6 +25,7 @@ class LocationsRepository extends ServiceEntityRepository
             ->addSelect('wp', 'p')
             ->andWhere('l.user = :user')
             ->setParameter('user', $user)
+            ->OrderBy('l.name', 'ASC')
             ->getQuery()
             ->getResult();
     }

--- a/src/Repository/PlantsRepository.php
+++ b/src/Repository/PlantsRepository.php
@@ -22,6 +22,7 @@ class PlantsRepository extends ServiceEntityRepository
     public function findAllByUser(UserInterface $user)
     {
         return $this->getQueryBuilderFindAllByUser($user)
+            ->OrderBy('p.name', 'ASC')
             ->getQuery()
             ->getResult();
     }

--- a/src/Service/Fitness/FitnessInformation.php
+++ b/src/Service/Fitness/FitnessInformation.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Service\Fitness;
+
+use App\Enum\FitnessStatus;
+use App\Enum\RequirementInterface;
+
+class FitnessInformation
+{
+    /** @var FitnessStatus $status */
+    private FitnessStatus $status;
+
+    /** @var array<RequirementInterface, RequirementInterface> $missmatches */
+    private array $missmatches;
+
+    public function __construct(
+        private int $locationId
+    )
+    {
+        $this->missmatches = [];
+    }
+
+    public function getStatus(): FitnessStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(FitnessStatus $status): void
+    {
+        $this->status = $status;
+    }
+
+    public function getMissmatches(): array
+    {
+        return $this->missmatches;
+    }
+
+    public function setMissmatches(array $missmatches): void
+    {
+        $this->missmatches = $missmatches;
+    }
+
+    /**
+     * @param array<RequirementInterface, RequirementInterface> $match
+     * @return void
+     */
+    public function addMissmatch(array $match): void
+    {
+       $this->missmatches[] = $match;
+    }
+
+    public function getLocationId(): int
+    {
+        return $this->locationId;
+    }
+
+    public function setLocationId(int $locationId): void
+    {
+        $this->locationId = $locationId;
+    }
+}

--- a/src/Service/Fitness/FitnessService.php
+++ b/src/Service/Fitness/FitnessService.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Service\Fitness;
+
+use App\Entity\Locations;
+use App\Entity\Plants;
+use App\Enum\FitnessStatus;
+use App\Enum\HumidityRequirement;
+use App\Enum\LightRequirement;
+use App\Enum\TemperatureRequirement;
+
+class FitnessService
+{
+    public function checkFitForPlantInLocation(
+        LightRequirement       $light,
+        TemperatureRequirement $temperature,
+        HumidityRequirement    $humidity,
+        Locations              $location
+    ): FitnessInformation
+    {
+        $fitnessInformation = new FitnessInformation($location->getId());
+
+        $count = 0;
+
+        // make sure we know where the mismatches come from
+        if ($light->matches($location->getLightCondition())) {
+            $count++;
+        } else {
+            $fitnessInformation->addMissmatch([$light->value => $location->getLightCondition()]);
+        }
+
+        if ($humidity->matches($location->getHumidityLevel())) {
+            $count++;
+        } else {
+            $fitnessInformation->addMissmatch([$humidity->value => $location->getHumidityLevel()]);
+        }
+
+        if ($temperature->matches($location->getTemperatureLevel())) {
+            $count++;
+        } else {
+            $fitnessInformation->addMissmatch([$temperature->value => $location->getTemperatureLevel()]);
+        }
+
+        match ($count) {
+            0 => $fitnessInformation->setStatus(FitnessStatus::none),
+            1, 2 => $fitnessInformation->setStatus(FitnessStatus::partly),
+            3 => $fitnessInformation->setStatus(FitnessStatus::perfect),
+        };
+
+        return $fitnessInformation;
+    }
+}


### PR DESCRIPTION
The provided API-Endpoint can be used to fetch the locations of a user and their respective fitting for a set or requirements.

This is then supposed to be used in the PlantType-Form as Choice-Options separated into Option-Groups. The fetching and rendering has yet to be handled in the templates.